### PR TITLE
Fix error causing VO2Max_prediction not to converge

### DIFF
--- a/running_performance/vo2max.py
+++ b/running_performance/vo2max.py
@@ -53,7 +53,7 @@ def VO2Max_prediction(distance, time, distance_to_predict):
     predicted_time = time * distance_to_predict / distance
 
     while True:
-        VO2Max_predicted = VO2Max(distance_to_predict, predicted_time)
+        VO2Max_predicted = VO2Max(distance_to_predict, predicted_time, None)
         difference = fabs(VO2Max_predicted - VO2Max_achieved) / VO2Max_achieved
         if difference <= epsilon:
             break

--- a/tests/test_vo2max.py
+++ b/tests/test_vo2max.py
@@ -10,3 +10,8 @@ def test_VO2Max_time(VO2Max_time):
     prediction = VO2Max_prediction(VO2Max_time['distance'], VO2Max_time['time'], VO2Max_time['predicted_distance'])
     difference = prediction - VO2Max_time['predicted_time']
     assert math.fabs(difference) / VO2Max_time['predicted_time'] < 0.005
+
+
+def test_VO2Max_regression_newton_flip_flop():
+    # Without disabling the rounding of VO2Max in the Newton method, it wouldn't converge but flip-flop
+    assert VO2Max_prediction(4890, 1569, 5000) == 26 * 60 + 46


### PR DESCRIPTION
Not disabling the rounding of the VO2Max method in the Newton method caused it not to converge.